### PR TITLE
Fix config indentation

### DIFF
--- a/chart/prometheus-mongodb-query-exporter/templates/configmap.yaml
+++ b/chart/prometheus-mongodb-query-exporter/templates/configmap.yaml
@@ -10,5 +10,5 @@ metadata:
     helm.sh/chart: {{ include "prometheus-mongodb-query-exporter.chart" . }}
 data:
   config.yaml: |
-    {{ .Values.config }}
+    {{- .Values.config | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
The current chart does not render the configuration inside the ConfigMap because it needs indenting.