### PR TITLE
add unit to queryTimeout docs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ log:
   development: false
   disableCaller: false
 global:
-  queryTimeout: 10
+  queryTimeout: 3s
   maxConnection: 3
   defaultCache: 0
 servers:


### PR DESCRIPTION
## Current situation
It is not clear from the docs that queryTimeout can expect a unit. (If not given it would be nanoseconds).

## Proposal
Document a 3s query timeout instead.
