### PR TITLE
feat(chart): support env variables from fieldPath (feat for #54)

### DIFF
--- a/chart/prometheus-mongodb-query-exporter/Chart.yaml
+++ b/chart/prometheus-mongodb-query-exporter/Chart.yaml
@@ -15,4 +15,4 @@ keywords:
 name: prometheus-mongodb-query-exporter
 sources:
 - https://github.com/raffis/mongodb-query-exporter
-version: 2.0.1
+version: 2.1.0

--- a/chart/prometheus-mongodb-query-exporter/templates/deployment.yaml
+++ b/chart/prometheus-mongodb-query-exporter/templates/deployment.yaml
@@ -53,6 +53,12 @@ spec:
         - secretRef:
             name: {{ .Values.envFromSecret }}
         {{- end }}
+        {{- range $key, $value := .Values.extraEnvFieldPath }}
+          - name: {{ $key }}
+            valueFrom:
+              fieldRef:
+                fieldPath: {{ $value }}
+          {{- end }}
         image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:

--- a/chart/prometheus-mongodb-query-exporter/values.yaml
+++ b/chart/prometheus-mongodb-query-exporter/values.yaml
@@ -127,6 +127,13 @@ envFromSecret: ""
 ##     key: password
 extraEnvSecrets: {}
 
+## A list of environment variables from fieldPath refs that will expose pod information to the container
+## This can be useful for enriching the custom metrics with pod information
+## example:
+## extraEnvFieldPath:
+##   POD_NAME: metadata.name
+extraEnvFieldPath: {}
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
## Current situation
<!--- Shortly describe the current situation -->
At the moment, it is not possible to create environment variables from `fieldPath`.
More details at https://github.com/raffis/mongodb-query-exporter/issues/54

## Proposal
<!--- Describe what this PR is intended to achieve -->
This PR adds the possibility to support environment variables from `fieldPath` in case we want to enrich the metrics with pod information.