### PR TITLE
fix: enforce yaml config #63

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,10 +161,9 @@ func initConfig() {
 		viper.AddConfigPath("/etc/mongodb_query_exporter")
 		// Search config in home directory with name ".mongodb_query_exporter" (without extension).
 		viper.AddConfigPath(usr.HomeDir + "/.mongodb_query_exporter")
-		//config file name without extension
-		//	viper.SetConfigName("config")
 	}
 
+	viper.SetConfigType("yaml")
 	if err := viper.ReadInConfig(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Current situation
Currently the exporter requires a .yaml suffix for the config file, otherwise it fails to start:
```
panic: Unsupported Config Type ""

goroutine 1 [running]:
github.com/raffis/mongodb-query-exporter/cmd.initConfig()
	/home/raffi/mongodb-query-exporter/cmd/root.go:169 +0x125
github.com/spf13/cobra.(*Command).preRun(...)
	/home/raffi/.gvm/pkgsets/go1.18/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:946
github.com/spf13/cobra.(*Command).execute(0x12ab340, {0xc000032190, 0x2, 0x2})
	/home/raffi/.gvm/pkgsets/go1.18/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:876 +0x563
github.com/spf13/cobra.(*Command).ExecuteC(0x12ab340)
	/home/raffi/.gvm/pkgsets/go1.18/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/home/raffi/.gvm/pkgsets/go1.18/global/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/raffis/mongodb-query-exporter/cmd.Execute(...)
	/home/raffi/mongodb-query-exporter/cmd/root.go:118
main.main()
	/home/raffi/mongodb-query-exporter/main.go:8 +0x25
exit status 2
```

## Proposal
Config type is now always yaml no matter the file suffix given.
