### PR TITLE
Fix helm deployment template to use Chart.AppVersion when no values are supplied

### DIFF
--- a/chart/mongodb-query-exporter/templates/deployment.yaml
+++ b/chart/mongodb-query-exporter/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               fieldRef:
                 fieldPath: {{ $value }}
           {{- end }}
-        image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --bind={{ printf ":%s" .Values.port }}


### PR DESCRIPTION
## Current situation
If `image.tag` is not set via helm values, the helm chart version is used as the image tag to pull the image which fails with the kubernetes event
```
Failed to pull image "ghcr.io/raffis/mongodb-query-exporter:3.0.0": rpc error: code = Unknown desc = Error response from daemon: manifest unknown
```
because the chart version currently is `3.0.0`, but no image tag `3.0.0` exists, the latest image tag is `2.0.1`.

## Proposal
The PR fixes the helm deployment template so that either `.Values.image.tag` or else `.Chart.AppVersion` is used as the image tag (tested both with my local k8s cluster).