### PR TITLE
fix: support /etc/mongodb-query-exporter as default config lookup path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN make deps build
 
 FROM gcr.io/distroless/base
 COPY --from=builder /go/src/github.com/raffis/mongodb-query-exporter/mongodb-query-exporter /bin/mongodb-query-exporter
-
-ENV MDBEXPORTER_CONFIG /etc/mongodb-query-exporter/config.yaml
 USER 1000:1000
 
 EXPOSE      9412

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -157,6 +157,7 @@ func initConfig() {
 		}
 
 		// System wide config
+		viper.AddConfigPath("/etc/mongodb-query-exporter")
 		viper.AddConfigPath("/etc/mongodb_query_exporter")
 	}
 


### PR DESCRIPTION
## Current situation
See #89 

## Proposal
Add compatibility fix.
