### PR TITLE
feat: add server label to metrics #161

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -34,9 +34,9 @@ type integrationTest struct {
 
 func TestMetricsConfigv2(t *testing.T) {
 	expected := map[string]string{
-		"myapp_example_simplevalue_total":    `name:"myapp_example_simplevalue_total" help:"Simple gauge metric" type:GAUGE metric:<gauge:<value:2 > > `,
-		"myapp_example_processes_total":      `name:"myapp_example_processes_total" help:"The total number of processes in a job queue" type:GAUGE metric:<label:<name:"status" value:"postponed" > label:<name:"type" value:"foobar" > gauge:<value:2 > > metric:<label:<name:"status" value:"processing" > label:<name:"type" value:"bar" > gauge:<value:1 > > `,
-		"myapp_events_total":                 `name:"myapp_events_total" help:"The total number of events (created 1h ago or newer)" type:GAUGE metric:<label:<name:"type" value:"bar" > gauge:<value:2 > > metric:<label:<name:"type" value:"foo" > gauge:<value:1 > > `,
+		"myapp_example_simplevalue_total":    `name:"myapp_example_simplevalue_total" help:"Simple gauge metric" type:GAUGE metric:<label:<name:"server" value:"main" > gauge:<value:2 > > `,
+		"myapp_example_processes_total":      `name:"myapp_example_processes_total" help:"The total number of processes in a job queue" type:GAUGE metric:<label:<name:"server" value:"main" > label:<name:"status" value:"postponed" > label:<name:"type" value:"foobar" > gauge:<value:2 > > metric:<label:<name:"server" value:"main" > label:<name:"status" value:"processing" > label:<name:"type" value:"bar" > gauge:<value:1 > > `,
+		"myapp_events_total":                 `name:"myapp_events_total" help:"The total number of events (created 1h ago or newer)" type:GAUGE metric:<label:<name:"server" value:"main" > label:<name:"type" value:"bar" > gauge:<value:2 > > metric:<label:<name:"server" value:"main" > label:<name:"type" value:"foo" > gauge:<value:1 > > `,
 		"mongodb_query_exporter_query_total": `name:"mongodb_query_exporter_query_total" help:"How many MongoDB queries have been processed, partitioned by metric, server and status" type:COUNTER metric:<label:<name:"aggregation" value:"aggregation_0" > label:<name:"result" value:"SUCCESS" > label:<name:"server" value:"main" > counter:<value:1 > > metric:<label:<name:"aggregation" value:"aggregation_1" > label:<name:"result" value:"SUCCESS" > label:<name:"server" value:"main" > counter:<value:1 > > metric:<label:<name:"aggregation" value:"aggregation_2" > label:<name:"result" value:"SUCCESS" > label:<name:"server" value:"main" > counter:<value:1 > > `,
 	}
 
@@ -63,6 +63,12 @@ func TestMetricsConfigv2(t *testing.T) {
 			name:            "integration test using config v3.0 and mongodb:5.0",
 			configPath:      "../example/configv3.yaml",
 			mongodbImage:    "mongo:5.0",
+			expectedMetrics: expected,
+		},
+		integrationTest{
+			name:            "integration test using config v3.0 and mongodb:6.0",
+			configPath:      "../example/configv3.yaml",
+			mongodbImage:    "mongo:6.0",
 			expectedMetrics: expected,
 		},
 	}

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -86,7 +86,7 @@ func TestInitializeMetrics(t *testing.T) {
 			expected: `
 				# HELP simple foobar
 				# TYPE simple gauge
-				simple{foo="bar"} 1
+				simple{foo="bar",server="main"} 1
 			`,
 		},
 		aggregationTest{
@@ -108,7 +108,7 @@ func TestInitializeMetrics(t *testing.T) {
 			expected: `
 				# HELP simple foobar
 				# TYPE simple gauge
-				simple 2
+				simple{server="main"} 2
 			`,
 		},
 		aggregationTest{
@@ -134,7 +134,7 @@ func TestInitializeMetrics(t *testing.T) {
 			counter_total{aggregation="aggregation_0",result="SUCCESS",server="main"} 1
 			# HELP simple foobar
 			# TYPE simple gauge
-			simple 2
+			simple{server="main"} 2
 			`,
 		},
 		aggregationTest{
@@ -169,7 +169,7 @@ func TestInitializeMetrics(t *testing.T) {
 			expected: `
 				# HELP simple_gauge_value_not_found_overridden overridden
 				# TYPE simple_gauge_value_not_found_overridden gauge
-				simple_gauge_value_not_found_overridden 12
+				simple_gauge_value_not_found_overridden{server="main"} 12
 			`,
 		},
 		aggregationTest{
@@ -271,7 +271,7 @@ func TestInitializeMetrics(t *testing.T) {
 			expected: `
 				# HELP simple_gauge_label foobar
 				# TYPE simple_gauge_label gauge
-				simple_gauge_label{foo="bar"} 1
+				simple_gauge_label{foo="bar",server="main"} 1
 			`,
 		},
 		aggregationTest{
@@ -303,11 +303,11 @@ func TestInitializeMetrics(t *testing.T) {
 			expected: `
 				# HELP simple_gauge_label foobar
 				# TYPE simple_gauge_label gauge
-				simple_gauge_label{foo="bar"} 1
+				simple_gauge_label{foo="bar",server="main"} 1
 
 				# HELP simple_gauge_label_with_constant bar
 				# TYPE simple_gauge_label_with_constant gauge
-				simple_gauge_label_with_constant{foo="bar", foobar="foo"} 1
+				simple_gauge_label_with_constant{foo="bar",foobar="foo",server="main"} 1
 			`,
 		},
 	}
@@ -369,12 +369,12 @@ func TestCachedMetric(t *testing.T) {
 			expected: `
 				# HELP simple_gauge_no_cache foobar
 				# TYPE simple_gauge_no_cache gauge
-				simple_gauge_no_cache 1
+				simple_gauge_no_cache{server="main"} 1
 			`,
 			expectedCached: `
 				# HELP simple_gauge_no_cache foobar
 				# TYPE simple_gauge_no_cache gauge
-				simple_gauge_no_cache 2
+				simple_gauge_no_cache{server="main"} 2
 			`,
 		},
 		aggregationTest{
@@ -397,12 +397,12 @@ func TestCachedMetric(t *testing.T) {
 			expected: `
 				# HELP simple_gauge_cached Cached for 60s
 				# TYPE simple_gauge_cached gauge
-				simple_gauge_cached 1
+				simple_gauge_cached{server="main"} 1
 			`,
 			expectedCached: `
 				# HELP simple_gauge_cached Cached for 60s
 				# TYPE simple_gauge_cached gauge
-				simple_gauge_cached 1
+				simple_gauge_cached{server="main"} 1
 			`,
 		},
 	}


### PR DESCRIPTION
## Current situation
Currently it is not possible to declare the same metric name from the same aggreation for multiple services.
The result is just one metric instead one metric per server.

## Proposal
Add server label to metrics.
Note this is a breaking change since metrics which have a server label configured will not behave the same anymore.
