### PR TITLE
fix(chart): rework labeling to make additional label work (Closes #173)

### DIFF
--- a/chart/mongodb-query-exporter/Chart.yaml
+++ b/chart/mongodb-query-exporter/Chart.yaml
@@ -15,4 +15,4 @@ keywords:
 name: mongodb-query-exporter
 sources:
 - https://github.com/raffis/mongodb-query-exporter
-version: 4.0.0
+version: 4.0.1

--- a/chart/mongodb-query-exporter/templates/_helpers.tpl
+++ b/chart/mongodb-query-exporter/templates/_helpers.tpl
@@ -68,13 +68,14 @@ Determine configmap name, can either be the self-created of an existing one
 {{/*
 Common labels
 */}}
-{{- define "mongodb-query-exporter.labels" -}}{{- if .Values.chartLabels }}
-    app.kubernetes.io/name: {{ include "mongodb-query-exporter.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "mongodb-query-exporter.chart" . }}
+{{- define "mongodb-query-exporter.labels" -}}
+{{ if .Values.chartLabels -}}
+app.kubernetes.io/name: {{ include "mongodb-query-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "mongodb-query-exporter.chart" . }}
 {{- end -}}
-{{- with .Values.labels }}
-    {{ . | toYaml }}
+{{ if .Values.labels }}
+{{ toYaml .Values.labels }}
 {{- end -}}
 {{- end -}}

--- a/chart/mongodb-query-exporter/templates/configmap.yaml
+++ b/chart/mongodb-query-exporter/templates/configmap.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mongodb-query-exporter.configName" . }}
-  {{- with ( include "mongodb-query-exporter.labels" . ) }}
-  labels:
-    {{- . }}
-  {{- end }}
+  labels: {{- include "mongodb-query-exporter.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/deployment.yaml
+++ b/chart/mongodb-query-exporter/templates/deployment.yaml
@@ -2,10 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mongodb-query-exporter.fullname" . }}
-  {{- with ( include "mongodb-query-exporter.labels" . ) }}
-  labels:
-    {{- . }}
-  {{- end }}
+  labels: {{- include "mongodb-query-exporter.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/podmonitor.yaml
+++ b/chart/mongodb-query-exporter/templates/podmonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "mongodb-query-exporter.fullname" . }}
-  {{- $labels := merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.podMonitor.labels -}}
-  {{- with $labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{- merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.podMonitor.labels | toYaml | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/prometheusrule.yaml
+++ b/chart/mongodb-query-exporter/templates/prometheusrule.yaml
@@ -4,11 +4,7 @@ kind: PrometheusRule
 metadata:
 metadata:
   name: {{ template "mongodb-query-exporter.fullname" . }}
-  {{- $labels := merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.prometheusRule.labels -}} 
-  {{- with $labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{- merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.prometheusRule.labels | toYaml | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/secret.yaml
+++ b/chart/mongodb-query-exporter/templates/secret.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mongodb-query-exporter.secretName" . }}
-  {{- with ( include "mongodb-query-exporter.labels" . ) }}
-  labels:
-    {{- . }}
-  {{- end }}
+  labels: {{- include "mongodb-query-exporter.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/service.yaml
+++ b/chart/mongodb-query-exporter/templates/service.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb-query-exporter.fullname" . }}
-  {{- $labels := merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.service.labels -}}
-  {{- with $labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{- merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.service.labels | toYaml | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/serviceaccount.yaml
+++ b/chart/mongodb-query-exporter/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "mongodb-query-exporter.serviceAccountName" . }}
-  {{- with ( include "mongodb-query-exporter.labels" . ) }}
-  labels:
-    {{- . }}
-  {{- end }}
+  labels: {{- include "mongodb-query-exporter.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/mongodb-query-exporter/templates/servicemonitor.yaml
+++ b/chart/mongodb-query-exporter/templates/servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mongodb-query-exporter.fullname" . }}
-  {{- $labels := merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.serviceMonitor.labels -}} 
-  {{- with $labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{- merge ( include "mongodb-query-exporter.labels" . | fromYaml) .Values.serviceMonitor.labels | toYaml | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Current situation

See #173

## Proposal

This PR refactors the way the labels are defined in the `_helpers.tpl` file and the way they are used in every resource. It also includes a few simplifications (getting rid of the `with` blocks in favor of direct references) in order to make reasoning about indentation much simpler.

I tested the difference in result, and you'll find the diffs below!

### Test case

I made sure to enable every resource that is optional to render everything that is supported by the chart. Essentially, the tests were ran with the following diff over the default `values.yaml` file:

```diff
 affinity: {}

 chartLabels: true

 labels: {}

 annotations: {}

 extraArgs:

 fullnameOverride: ""

 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/raffis/mongodb-query-exporter
   tag:

 imagePullSecrets: []

 livenessProbe:
   httpGet:
     path: /healthz
     port: metrics
   initialDelaySeconds: 10


 # List of MongoDB servers (Injected as secret env)
 mongodb: []
 # - [mongodb[+srv]://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]

 # The MongoDB query exporter config (required if exstingConfig.name is not set)
 config: |
 #  version: 2.0
 #  bind: 0.0.0.0:9412
 #  log:
 #    encoding: json
 #    level: info
 #    development: false
 #    disableCaller: false
 #  global:
 #    queryTimeout: 10
 #    maxConnection: 3
 #    defaultCache: 5
 #  servers:
 #  - name: main
 #    uri: mongodb://localhost:27017 #Will be overwritten by the "mongodb" value
 #  metrics:
 #  - name: myapp_example_simplevalue_total
 #    type: gauge #Can also be empty, the default is gauge
 #    servers: [main] #Can also be empty, if empty the metric will be used for every server defined
 #    help: 'Simple gauge metric'
 #    value: total
 #    labels: []
 #    mode: pull
 #    cache: 0
 #    constLabels: []
 #    database: mydb
 #    collection: objects
 #    pipeline: |
 #      [
 #        {"$count":"total"}
 #      ]

 # Name of an externally managed configmap (in the same namespace) containing the mongodb-query-exporter yaml config
 # If this is provided, the value config is ignored. Note the config needs a key named `config.yaml` which contains the query exporters config.
 existingConfig:
   name: ""

 # Name of an externally managed secret (in the same namespace) containing as list of MongoDB envs (connectin URI)
 # If this is provided, the value mongodb is ignored.
 existingSecret:
   name: ""

 nameOverride: ""

 nodeSelector: {}

 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security
 secretMounts: []
 #  - name: mongodb-certs
 #    secretName: mongodb-certs
 #    path: /ssl

 # Add additional containers (sidecars)
 extraContainers:

 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "metrics"

 port: "9412"

 # Change the metrics path
 metricsPath: /metrics

 priorityClassName: ""

 readinessProbe:
   httpGet:
     path: /healthz
     port: metrics
   initialDelaySeconds: 10

 replicas: 1

 resources: {}
 # limits:
 #   cpu: 250m
 #   memory: 192Mi
 # requests:
 #   cpu: 100m
 #   memory: 128Mi

 # Extra environment variables that will be passed into the exporter pod
 env: {}

 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc
 envFromSecret: ""

 ## A list of environment variables from secret refs that will be passed into the exporter pod
 ## example:
 ## extraEnvSecrets:
 ##   MY_ENV:
 ##     secret: my-secret
 ##     key: password
 extraEnvSecrets: {}

 ## A list of environment variables from fieldPath refs that will expose pod information to the container
 ## This can be useful for enriching the custom metrics with pod information
 ## example:
 ## extraEnvFieldPath:
 ##   POD_NAME: metadata.name
 extraEnvFieldPath: {}

 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["all"]
   readOnlyRootFilesystem: true
   runAsGroup: 10000
   runAsNonRoot: true
   runAsUser: 10000

 service:
-  enabled: false
+  enabled: true
   labels: {}
   annotations: {}
   port: 9412
   type: ClusterIP

 serviceAccount:
   create: true
   # If create is true and name is not set, then a name is generated using the
   # fullname template.
   name:

 # Creates a PodSecurityPolicy and the role/rolebinding
 # allowing the serviceaccount to use it
 podSecurityPolicy:
-  enabled: false
+  enabled: true

 # Prometheus operator ServiceMonitor
 serviceMonitor:
-  enabled: false
+  enabled: true
   interval: 30s
   scrapeTimeout: 10s
   namespace:
   labels: {}
   targetLabels: []
   metricRelabelings: []
   sampleLimit: 0

 # Prometheus operator PodMonitor
 podMonitor:
-  enabled: false
+  enabled: true
   interval: 30s
   scrapeTimeout: 10s
   namespace:
   labels: {}
   targetLabels: []
   metricRelabelings: []
   sampleLimit: 0

 prometheusRule:
   ## If true, a PrometheusRule CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator
   ##
   ## The rules will be processed as Helm template, allowing to set variables in them.
-  enabled: false
+  enabled: true
   #  namespace: monitoring
   labels: {}
   rules: []

 tolerations: []
```

Also, for each before/after, you'll find two cases:

- One with no additional labels (so, just the `values.yaml` with the above diff)
- One with 2 additional labels, a.k.a. the following diff over the above `values.yaml`:

```diff
 affinity: {}

 chartLabels: true

-labels: {}
+labels:
+  label1: "value1"
+  label2: "value2"

 annotations: {}

 extraArgs:

 fullnameOverride: ""

 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/raffis/mongodb-query-exporter
   tag:

 imagePullSecrets: []

 livenessProbe:
   httpGet:
     path: /healthz
     port: metrics
   initialDelaySeconds: 10


 # List of MongoDB servers (Injected as secret env)
 mongodb: []
 # - [mongodb[+srv]://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]

 # The MongoDB query exporter config (required if exstingConfig.name is not set)
 config: |
 #  version: 2.0
 #  bind: 0.0.0.0:9412
 #  log:
 #    encoding: json
 #    level: info
 #    development: false
 #    disableCaller: false
 #  global:
 #    queryTimeout: 10
 #    maxConnection: 3
 #    defaultCache: 5
 #  servers:
 #  - name: main
 #    uri: mongodb://localhost:27017 #Will be overwritten by the "mongodb" value
 #  metrics:
 #  - name: myapp_example_simplevalue_total
 #    type: gauge #Can also be empty, the default is gauge
 #    servers: [main] #Can also be empty, if empty the metric will be used for every server defined
 #    help: 'Simple gauge metric'
 #    value: total
 #    labels: []
 #    mode: pull
 #    cache: 0
 #    constLabels: []
 #    database: mydb
 #    collection: objects
 #    pipeline: |
 #      [
 #        {"$count":"total"}
 #      ]

 # Name of an externally managed configmap (in the same namespace) containing the mongodb-query-exporter yaml config
 # If this is provided, the value config is ignored. Note the config needs a key named `config.yaml` which contains the query exporters config.
 existingConfig:
   name: ""

 # Name of an externally managed secret (in the same namespace) containing as list of MongoDB envs (connectin URI)
 # If this is provided, the value mongodb is ignored.
 existingSecret:
   name: ""

 nameOverride: ""

 nodeSelector: {}

 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security
 secretMounts: []
 #  - name: mongodb-certs
 #    secretName: mongodb-certs
 #    path: /ssl

 # Add additional containers (sidecars)
 extraContainers:

 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "metrics"

 port: "9412"

 # Change the metrics path
 metricsPath: /metrics

 priorityClassName: ""

 readinessProbe:
   httpGet:
     path: /healthz
     port: metrics
   initialDelaySeconds: 10

 replicas: 1

 resources: {}
 # limits:
 #   cpu: 250m
 #   memory: 192Mi
 # requests:
 #   cpu: 100m
 #   memory: 128Mi

 # Extra environment variables that will be passed into the exporter pod
 env: {}

 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc
 envFromSecret: ""

 ## A list of environment variables from secret refs that will be passed into the exporter pod
 ## example:
 ## extraEnvSecrets:
 ##   MY_ENV:
 ##     secret: my-secret
 ##     key: password
 extraEnvSecrets: {}

 ## A list of environment variables from fieldPath refs that will expose pod information to the container
 ## This can be useful for enriching the custom metrics with pod information
 ## example:
 ## extraEnvFieldPath:
 ##   POD_NAME: metadata.name
 extraEnvFieldPath: {}

 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["all"]
   readOnlyRootFilesystem: true
   runAsGroup: 10000
   runAsNonRoot: true
   runAsUser: 10000

 service:
   enabled: true
   labels: {}
   annotations: {}
   port: 9412
   type: ClusterIP

 serviceAccount:
   create: true
   # If create is true and name is not set, then a name is generated using the
   # fullname template.
   name:

 # Creates a PodSecurityPolicy and the role/rolebinding
 # allowing the serviceaccount to use it
 podSecurityPolicy:
   enabled: true

 # Prometheus operator ServiceMonitor
 serviceMonitor:
   enabled: true
   interval: 30s
   scrapeTimeout: 10s
   namespace:
   labels: {}
   targetLabels: []
   metricRelabelings: []
   sampleLimit: 0

 # Prometheus operator PodMonitor
 podMonitor:
   enabled: true
   interval: 30s
   scrapeTimeout: 10s
   namespace:
   labels: {}
   targetLabels: []
   metricRelabelings: []
   sampleLimit: 0

 prometheusRule:
   ## If true, a PrometheusRule CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator
   ##
   ## The rules will be processed as Helm template, allowing to set variables in them.
   enabled: true
   #  namespace: monitoring
   labels: {}
   rules: []

 tolerations: []
```

### Before - Without additional labels

The following is the diff before/after this PR with empty additional labels:

```diff
 ---
 # Source: mongodb-query-exporter/templates/podsecuritypolicy.yaml
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 spec:
   privileged: false
   allowPrivilegeEscalation: false
   requiredDropCapabilities:
    - ALL
   volumes:
     - 'secret'
   hostNetwork: false
   hostIPC: false
   hostPID: false
   runAsUser:
     rule: 'MustRunAs'
     ranges:
       - min: 1
         max: 65535
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
       - min: 1
         max: 65535
   fsGroup:
     rule: 'MustRunAs'
     ranges:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
 ---
 # Source: mongodb-query-exporter/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 ---
 # Source: mongodb-query-exporter/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 type: Opaque
 data:
 ---
 # Source: mongodb-query-exporter/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 data:
   config.yaml: |
 ---
 # Source: mongodb-query-exporter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
   - release-name-mongodb-query-exporter
 ---
 # Source: mongodb-query-exporter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: release-name-mongodb-query-exporter
 subjects:
 - kind: ServiceAccount
   name: release-name-mongodb-query-exporter
   namespace: prod-batch
 ---
 # Source: mongodb-query-exporter/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
 spec:
   ports:
     - port: 9412
       targetPort: metrics
       protocol: TCP
       name: metrics
   selector:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
   type: ClusterIP
 ---
 # Source: mongodb-query-exporter/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: mongodb-query-exporter
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       annotations:
         checksum/config: 6fdb0b414592727876b529ddbdf39a303bd05869cb68b57abd37d849fa315f3c
         checksum/secret: 05c39dbc7650585db6ecefe139ef93d4a80128a38e2fa5cc87a634d9161960ad
       labels:
         app.kubernetes.io/name: mongodb-query-exporter
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: release-name-mongodb-query-exporter
       containers:
       - name: mongodb-query-exporter
         envFrom:
         - secretRef:
             name: release-name-mongodb-query-exporter
         env:
         image: "ghcr.io/raffis/mongodb-query-exporter:2.0.3"
         imagePullPolicy: IfNotPresent
         args:
         - --bind=:9412
         - --path=/metrics
         ports:
         - name: metrics
           containerPort: 9412
           protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz
             port: metrics
           initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: metrics
           initialDelaySeconds: 10
         resources:
           {}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - all
           readOnlyRootFilesystem: true
           runAsGroup: 10000
           runAsNonRoot: true
           runAsUser: 10000
         volumeMounts:
         - name: config
           mountPath: /etc/mongodb_query_exporter
       volumes:
       - name: config
         configMap:
           name: release-name-mongodb-query-exporter
       terminationGracePeriodSeconds: 30
 ---
 # Source: mongodb-query-exporter/templates/podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
 spec:
   podMetricsEndpoints:
   - port: metrics
     path: /metrics
     interval: 30s
     scrapeTimeout: 10s

   namespaceSelector:
     matchNames:
     - prod-batch
   selector:
     matchLabels:
       app.kubernetes.io/name: mongodb-query-exporter
       app.kubernetes.io/instance: release-name
   sampleLimit: 0
 ---
 # Source: mongodb-query-exporter/templates/prometheusrule.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
 spec:
 ---
 # Source: mongodb-query-exporter/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
 spec:
   endpoints:
   - port: metrics
     path: /metrics
     interval: 30s
     scrapeTimeout: 10s

   namespaceSelector:
     matchNames:
     - prod-batch
   selector:
     matchLabels:
       app.kubernetes.io/name: mongodb-query-exporter
       app.kubernetes.io/instance: release-name
   sampleLimit: 0
```

As expected: no diff, so no breaking change!

### Before - With 2 additional labels

The following is the diff before/after this PR with 2 additional labels:

```diff
 ---
 # Source: mongodb-query-exporter/templates/podsecuritypolicy.yaml
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 spec:
   privileged: false
   allowPrivilegeEscalation: false
   requiredDropCapabilities:
    - ALL
   volumes:
     - 'secret'
   hostNetwork: false
   hostIPC: false
   hostPID: false
   runAsUser:
     rule: 'MustRunAs'
     ranges:
       - min: 1
         max: 65535
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
       - min: 1
         max: 65535
   fsGroup:
     rule: 'MustRunAs'
     ranges:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: true
 ---
 # Source: mongodb-query-exporter/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 ---
 # Source: mongodb-query-exporter/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 type: Opaque
 data:
 ---
 # Source: mongodb-query-exporter/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 data:
   config.yaml: |
 ---
 # Source: mongodb-query-exporter/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
   - release-name-mongodb-query-exporter
 ---
 # Source: mongodb-query-exporter/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: release-name-mongodb-query-exporter
 subjects:
 - kind: ServiceAccount
   name: release-name-mongodb-query-exporter
   namespace: prod-batch
 ---
 # Source: mongodb-query-exporter/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
+    label2: value2
 spec:
   ports:
     - port: 9412
       targetPort: metrics
       protocol: TCP
       name: metrics
   selector:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
   type: ClusterIP
 ---
 # Source: mongodb-query-exporter/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/name: mongodb-query-exporter
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
-label2: value2
+    label2: value2
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: mongodb-query-exporter
       app.kubernetes.io/instance: release-name
   template:
     metadata:
       annotations:
-        checksum/config: e303e57ca542a36318800d1c6ebc267b4cb0c3eb446dd94f4eab15033e70bddb
-        checksum/secret: b1eb96f28aa7eb5aec85efd1c00496e343ce4e567bb82604071e20a269568fbc
+        checksum/config: 83086500652697d47fe70f3379afaadfc31b2392b412a688b946ccc518e604f4
+        checksum/secret: 550e7228ab17e8888ec63a9e2d7ee5b944361a19cbef4169d5a57ec24257748e
       labels:
         app.kubernetes.io/name: mongodb-query-exporter
         app.kubernetes.io/instance: release-name
     spec:
       serviceAccountName: release-name-mongodb-query-exporter
       containers:
       - name: mongodb-query-exporter
         envFrom:
         - secretRef:
             name: release-name-mongodb-query-exporter
         env:
         image: "ghcr.io/raffis/mongodb-query-exporter:2.0.3"
         imagePullPolicy: IfNotPresent
         args:
         - --bind=:9412
         - --path=/metrics
         ports:
         - name: metrics
           containerPort: 9412
           protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz
             port: metrics
           initialDelaySeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: metrics
           initialDelaySeconds: 10
         resources:
           {}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - all
           readOnlyRootFilesystem: true
           runAsGroup: 10000
           runAsNonRoot: true
           runAsUser: 10000
         volumeMounts:
         - name: config
           mountPath: /etc/mongodb_query_exporter
       volumes:
       - name: config
         configMap:
           name: release-name-mongodb-query-exporter
       terminationGracePeriodSeconds: 30
 ---
 # Source: mongodb-query-exporter/templates/podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
+    label2: value2
 spec:
   podMetricsEndpoints:
   - port: metrics
     path: /metrics
     interval: 30s
     scrapeTimeout: 10s

   namespaceSelector:
     matchNames:
     - prod-batch
   selector:
     matchLabels:
       app.kubernetes.io/name: mongodb-query-exporter
       app.kubernetes.io/instance: release-name
   sampleLimit: 0
 ---
 # Source: mongodb-query-exporter/templates/prometheusrule.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
+    label2: value2
 spec:
 ---
 # Source: mongodb-query-exporter/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: release-name-mongodb-query-exporter
   labels:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mongodb-query-exporter
     helm.sh/chart: mongodb-query-exporter-3.0.2
     label1: value1
+    label2: value2
 spec:
   endpoints:
   - port: metrics
     path: /metrics
     interval: 30s
     scrapeTimeout: 10s

   namespaceSelector:
     matchNames:
     - prod-batch
   selector:
     matchLabels:
       app.kubernetes.io/name: mongodb-query-exporter
       app.kubernetes.io/instance: release-name
   sampleLimit: 0
```

As we can see, it correctly fixes the indentation of the second label that was wrong, as per #173 . It also apparently fixes another unidentified bug where only the first additional label was included in some resources before this PR!

---

Disclaimer: the only case I didn't test is the case where one tries to
purposely unset all the labels - by keeping `labels` to `{}`, and setting the
`chartLabels` value to `false`.

Additional note: the diff was generated before #164 and therefore includes resources that no longer exist since then - discovered it when rebasing against `master` ;)
