### PR TITLE
feat: support info metrics #198

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The metrics are by default exposed at `/metrics`.
 curl localhost:9412/metrics
 ```
 
-## Configuration
+## Exporter configuration
 
 The exporter is looking for a configuration in `~/.mongodb_query_exporter/config.yaml` and `/etc/mongodb_query_exporter/config.yaml` or if set the path from the env `MDBEXPORTER_CONFIG`.
 
@@ -105,7 +105,7 @@ Note if you have multiple MongoDB servers you can inject an env variable for eac
 2. `MDBEXPORTER_SERVER_1_MONGODB_URI=mongodb://srv2:27017`
 3. ...
 
-### Configure your metrics
+## Configure metrics
 
 Since the v1.0.0 release you should use the config version v3.0 to profit from the latest features.
 See the configuration version matrix bellow.
@@ -219,6 +219,35 @@ aggregations:
 ```
 
 See more examples in the `/example` folder.
+
+### Info metrics
+
+By defining no actual value field but set `overrideEmpty` to `true` a metric can sill be exported
+with labels from the aggregation pipeline but the value is set to a static value taken from `emptyValue`.
+This is useful for exporting info metrics which can later be used for join queries.
+
+```yaml
+servers:
+- name: main
+  uri: mongodb://localhost:27017
+aggregations:
+- database: mydb
+  collection: objects
+  metrics:
+  - name: myapp_info
+    help: 'Info metric'
+    overrideEmpty: true
+    emptyValue: 1
+    labels:
+    - mylabel1
+    - mylabel2
+    constLabels:
+      region: eu-central-1
+  cache: 0
+  mode: pull
+  pipeline: `...`
+```
+
 
 ## Supported config versions
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -428,7 +428,17 @@ func (c *Collector) aggregate(aggregation *Aggregation, srv *server, ch chan<- p
 }
 
 func createMetric(srv *server, metric *Metric, result AggregationResult) (prometheus.Metric, error) {
-	value, err := metric.getValue(result)
+	var (
+		value float64
+		err   error
+	)
+
+	if metric.Value == "" && metric.OverrideEmpty {
+		value = float64(metric.EmptyValue)
+	} else {
+		value, err = metric.getValue(result)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -275,6 +275,47 @@ func TestInitializeMetrics(t *testing.T) {
 			`,
 		},
 		{
+			name: "Empty result and overrideEmpty is not set results in no metric",
+			aggregation: &Aggregation{
+				Metrics: []*Metric{
+					{
+						Name:   "no_result",
+						Type:   "gauge",
+						Help:   "foobar",
+						Value:  "total",
+						Labels: []string{"foo"},
+					},
+				},
+				Pipeline: "[{\"$match\":{\"foo\":\"bar\"}}]",
+			},
+			docs:     []interface{}{},
+			expected: ``,
+		},
+		{
+			name: "Metric without a value but overrideEmpty is still created",
+			aggregation: &Aggregation{
+				Metrics: []*Metric{
+					{
+						Name:          "simple_info_metric",
+						Type:          "gauge",
+						Help:          "foobar",
+						OverrideEmpty: true,
+						EmptyValue:    1,
+						Labels:        []string{"foo"},
+					},
+				},
+				Pipeline: "[{\"$match\":{\"foo\":\"bar\"}}]",
+			},
+			docs: []interface{}{AggregationResult{
+				"foo": "bar",
+			}},
+			expected: `
+				# HELP simple_info_metric foobar
+				# TYPE simple_info_metric gauge
+				simple_info_metric{foo="bar",server="main"} 1
+			`,
+		},
+		{
 			name: "Export multiple metrics from the same aggregation",
 			aggregation: &Aggregation{
 				Metrics: []*Metric{


### PR DESCRIPTION
## Current situation
No support for info metrics. 
See workaround mentioned in #198.

## Proposal
Support info metrics by allowing an empty `value` field but the possibility to set `overrideEmpty` to true.
That way `emptyValue` can be set (usually) to `1`.
