### PR TITLE
feat: add log info

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -251,7 +251,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 				if err == nil {
 					result = ResultSuccess
 				} else {
-					c.logger.Errorf("failed to generate metric: %s", err)
+					c.logger.Errorf("failed to generate metric", "err", err, "name", srv.name)
 
 					result = ResultError
 				}


### PR DESCRIPTION
## Current situation
<!--- Shortly describe the current situation -->
logs are: `failed to generate metric: context deadline exceeded` without give information about the metric name. Maybe, it could be possible to improve the aggregate pipeline of the specified query.

## Proposal
<!--- Describe what this PR is intended to achieve -->
Add name of the metric which generates the error