### PR TITLE
feat: add labels on pods deployment

### DIFF
--- a/chart/mongodb-query-exporter/templates/deployment.yaml
+++ b/chart/mongodb-query-exporter/templates/deployment.yaml
@@ -22,8 +22,7 @@ spec:
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "mongodb-query-exporter.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "mongodb-query-exporter.labels" . | nindent 4 }}
     spec:
       serviceAccountName: {{ template "mongodb-query-exporter.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
## Current situation

Currently, the labels associated with the deployment are not reflected on the pods created by it.

## Proposal

The labels associated with the deployment and the pods resulting from it are the same.
