### PR TITLE
feat: Add extraVolume value to values and deployment for Helm Chart

### DIFF
--- a/chart/mongodb-query-exporter/templates/deployment.yaml
+++ b/chart/mongodb-query-exporter/templates/deployment.yaml
@@ -98,6 +98,9 @@ spec:
         secret:
           secretName: {{ .secretName }}
       {{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/chart/mongodb-query-exporter/values.yaml
+++ b/chart/mongodb-query-exporter/values.yaml
@@ -88,6 +88,9 @@ secretMounts: []
 # Add additional containers (sidecars)
 extraContainers:
 
+# Add additional volumes
+extraVolumes:
+
 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "metrics"


### PR DESCRIPTION
## Current situation
<!--- Shortly describe the current situation -->

You cannot add extra volumes to the deployment. However I want to add one for a sidecar of this deployment, but currently I'd need to extract the kustomize build out of the helm chart and patch that. 

## Proposal
<!--- Describe what this PR is intended to achieve -->

I added an `extraVolumes` value similar to the `extraContainers` value such that this is possible. Would love to see this included! Cheers