### PR TITLE
enhance error message for missing values

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -76,8 +76,7 @@ type Metric struct {
 var (
 	//Only Gauge is a supported metric types
 	ErrInvalidType = errors.New("unknown metric type provided. Only gauge is supported")
-	//The value was not found in the aggregation result set
-	ErrValueNotFound = errors.New("value not found in result set")
+	
 	//No cached metric available
 	ErrNotCached = errors.New("metric not available from cache")
 )
@@ -471,7 +470,7 @@ func (metric *Metric) getValue(result AggregationResult) (float64, error) {
 		}
 	}
 
-	return 0, ErrValueNotFound
+	return 0, fmt.Errorf("value for metric %s with key %s not found in result set", metric.Name, metric.Value)
 }
 
 func (metric *Metric) getLabels(result AggregationResult) ([]string, error) {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -142,14 +142,15 @@ func TestInitializeMetrics(t *testing.T) {
 			aggregation: &Aggregation{
 				Metrics: []*Metric{
 					{
-						Name: "simple_gauge_value_not_found",
-						Type: "gauge",
+						Name:  "simple_gauge_value_not_found",
+						Type:  "gauge",
+						Value: "total",
 					},
 				},
 				Pipeline: "[{\"$match\":{\"foo\":\"bar\"}}]",
 			},
 			docs: []interface{}{AggregationResult{}},
-			//error: "1 error occurred:\n\t* value not found in result set\n\n",
+			//error: "value for metric simple_gauge_value_not_found with key total not found in result set",
 			expected: ``,
 		},
 		{


### PR DESCRIPTION
The error message "value not found in result set" was not helpful in  identifying the failing metric.

This change enhances the error message to include the metric name and the key that was not found, making it easier to debug user-defined aggregations.

The new error message is:
  "value for metric <metric.Name> with key <metric.Value> not found in result set"

fixes gh-287
